### PR TITLE
fix: add agents_ids on create new chat

### DIFF
--- a/features/chats/store/chats.ts
+++ b/features/chats/store/chats.ts
@@ -33,6 +33,7 @@ export const useChatsStore = defineStore('chats', () => {
 
   const createChat = async (request: CreateChat) => {
     const chat = await createChatReq(request)
+    chat.agents_ids = [request.agent_id]
     chats.value.unshift(chat)
     return chat
   }

--- a/widgets/chats/current-chat/ui/CurrentChat.vue
+++ b/widgets/chats/current-chat/ui/CurrentChat.vue
@@ -102,7 +102,7 @@
   dayjs.extend(utc)
   const bridgeAgent = computed(() => agents.value.find((agent) => agent.id === BRIDGE_AGENT_ID)!)
   const currentAgent = ref<Agent>(structuredClone(toRaw(bridgeAgent.value)))
-  if (currentChat.value?.agents_ids.length === 1) {
+  if (currentChat.value?.agents_ids?.length === 1) {
     const agent = getAgentById(currentChat.value?.agents_ids[0])
     if (agent) {
       currentAgent.value = structuredClone(toRaw(agent))


### PR DESCRIPTION
- Add agents_ids field to new chat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to assign agents to chats directly during chat creation.

- **Bug Fixes**
	- Fixed an issue where the app could crash if the agent IDs for a chat were not properly initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->