### PR TITLE
feat: implement `is_enabled` for agents

### DIFF
--- a/src-tauri/.sqlx/query-261d9d3cc7411c57f4841f77eb64420c60854945bef7dc9a70919333a1a29185.json
+++ b/src-tauri/.sqlx/query-261d9d3cc7411c57f4841f77eb64420c60854945bef7dc9a70919333a1a29185.json
@@ -32,12 +32,18 @@
         "name": "updated_at",
         "ordinal": 5,
         "type_info": "Datetime"
+      },
+      {
+        "name": "is_enabled",
+        "ordinal": 6,
+        "type_info": "Bool"
       }
     ],
     "parameters": {
       "Right": 4
     },
     "nullable": [
+      false,
       false,
       false,
       false,

--- a/src-tauri/.sqlx/query-39b950fbd9c50c18a3bb5062811192db8d81ef5bf495f443505cd91d322c33ae.json
+++ b/src-tauri/.sqlx/query-39b950fbd9c50c18a3bb5062811192db8d81ef5bf495f443505cd91d322c33ae.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE agents SET is_enabled = $1 WHERE id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "39b950fbd9c50c18a3bb5062811192db8d81ef5bf495f443505cd91d322c33ae"
+}

--- a/src-tauri/.sqlx/query-502c6662e80b8dd95f046336381ab446f420dc413ee7a21125b66c48adfce8dd.json
+++ b/src-tauri/.sqlx/query-502c6662e80b8dd95f046336381ab446f420dc413ee7a21125b66c48adfce8dd.json
@@ -32,12 +32,18 @@
         "name": "updated_at",
         "ordinal": 5,
         "type_info": "Datetime"
+      },
+      {
+        "name": "is_enabled",
+        "ordinal": 6,
+        "type_info": "Bool"
       }
     ],
     "parameters": {
       "Right": 0
     },
     "nullable": [
+      false,
       false,
       false,
       false,

--- a/src-tauri/.sqlx/query-7aa8b6810628cd8454364b72239a500692a2fb37e065e098531c041bb7e76edf.json
+++ b/src-tauri/.sqlx/query-7aa8b6810628cd8454364b72239a500692a2fb37e065e098531c041bb7e76edf.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "\n        UPDATE agents\n        SET name = $2, description = $3, system_message = $4, updated_at = $5\n        WHERE id = $1\n        RETURNING id as \"id!\", name, description, system_message, created_at, updated_at\n        ",
+  "query": "\n        UPDATE agents\n        SET name = $2, description = $3, system_message = $4, updated_at = $5\n        WHERE id = $1\n        RETURNING\n            id as \"id!\", name, description, system_message, created_at, updated_at,\n            is_enabled\n        ",
   "describe": {
     "columns": [
       {
@@ -32,6 +32,11 @@
         "name": "updated_at",
         "ordinal": 5,
         "type_info": "Datetime"
+      },
+      {
+        "name": "is_enabled",
+        "ordinal": 6,
+        "type_info": "Bool"
       }
     ],
     "parameters": {
@@ -43,8 +48,9 @@
       false,
       false,
       false,
+      false,
       false
     ]
   },
-  "hash": "627488fa23eeb8ee7ee26abee91663034fe7487d05c0ec0c6f52c715d045c656"
+  "hash": "7aa8b6810628cd8454364b72239a500692a2fb37e065e098531c041bb7e76edf"
 }

--- a/src-tauri/.sqlx/query-96e478cec9c43587eb8864d3ac47021ace309978f9088e74ab702a17ca787022.json
+++ b/src-tauri/.sqlx/query-96e478cec9c43587eb8864d3ac47021ace309978f9088e74ab702a17ca787022.json
@@ -32,12 +32,18 @@
         "name": "updated_at",
         "ordinal": 5,
         "type_info": "Datetime"
+      },
+      {
+        "name": "is_enabled",
+        "ordinal": 6,
+        "type_info": "Bool"
       }
     ],
     "parameters": {
       "Right": 1
     },
     "nullable": [
+      false,
       false,
       false,
       false,

--- a/src-tauri/.sqlx/query-e9ee2a7198428c5e1ed4f342ec75488c122cacb6613e0aa20bf49a7d9990691a.json
+++ b/src-tauri/.sqlx/query-e9ee2a7198428c5e1ed4f342ec75488c122cacb6613e0aa20bf49a7d9990691a.json
@@ -32,12 +32,18 @@
         "name": "updated_at",
         "ordinal": 5,
         "type_info": "Datetime"
+      },
+      {
+        "name": "is_enabled",
+        "ordinal": 6,
+        "type_info": "Bool"
       }
     ],
     "parameters": {
       "Right": 1
     },
     "nullable": [
+      false,
       false,
       false,
       false,

--- a/src-tauri/db/migrations/20240319222540_add_is_enabled_to_agents.down.sql
+++ b/src-tauri/db/migrations/20240319222540_add_is_enabled_to_agents.down.sql
@@ -1,0 +1,4 @@
+-- Copyright 2024 StarfleetAI
+-- SPDX-License-Identifier: Apache-2.0
+
+ALTER TABLE agents DROP COLUMN is_enabled;

--- a/src-tauri/db/migrations/20240319222540_add_is_enabled_to_agents.up.sql
+++ b/src-tauri/db/migrations/20240319222540_add_is_enabled_to_agents.up.sql
@@ -1,0 +1,4 @@
+-- Copyright 2024 StarfleetAI
+-- SPDX-License-Identifier: Apache-2.0
+
+ALTER TABLE agents ADD COLUMN is_enabled BOOLEAN NOT NULL DEFAULT true;

--- a/src-tauri/db/seeds.sql
+++ b/src-tauri/db/seeds.sql
@@ -1,6 +1,17 @@
 -- Copyright 2024 StarfleetAI
 -- SPDX-License-Identifier: Apache-2.0
 
+INSERT INTO agents (
+    id, name, description, system_message, is_enabled, created_at, updated_at
+) VALUES
+    (1, 'Bridge', 'Your helpful assistant', 'You are an assistant for the "Bridge" - autonomous AI agents IDE, developed by StarfleetAI. Your role is to help user with his tasks.', 1, '2024-03-19T04:20:00.230289+00:00', '2024-03-19T04:20:00.230289+00:00')
+ON CONFLICT (id) DO UPDATE SET
+    name = excluded.name,
+    description = excluded.description,
+    system_message = excluded.system_message,
+    is_enabled = excluded.is_enabled,
+    updated_at = '2024-03-19T04:20:00.230289+00:00';
+
 INSERT INTO models (
     provider, name, context_length, max_tokens,
     text_in, text_out, image_in, image_out, audio_in, audio_out, function_calling,

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -25,6 +25,7 @@ pub struct Agent {
     pub description: String,
     pub system_message: String,
     pub ability_ids: Vec<i64>,
+    pub is_enabled: bool,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
 }
@@ -79,6 +80,7 @@ pub async fn list_agents(pool: State<'_, DbPool>) -> Result<AgentsList> {
             name: row.name,
             description: row.description,
             system_message: row.system_message,
+            is_enabled: row.is_enabled,
             ability_ids: abilities.get(&row.id).unwrap_or(&Vec::new()).clone(),
             created_at: row.created_at,
             updated_at: row.updated_at,
@@ -124,9 +126,24 @@ pub async fn create_agent(request: CreateAgent, pool: State<'_, DbPool>) -> Resu
         description: agent.description,
         system_message: agent.system_message,
         ability_ids: request.ability_ids,
+        is_enabled: agent.is_enabled,
         created_at: agent.created_at,
         updated_at: agent.updated_at,
     })
+}
+
+/// Update `is_enabled` field for agent by id.
+///
+/// # Errors
+///
+/// Returns error if any error occurs while accessing database.
+#[tauri::command]
+pub async fn update_agent_is_enabled(
+    id: i64,
+    is_enabled: bool,
+    pool: State<'_, DbPool>,
+) -> Result<()> {
+    repo::agents::update_is_enabled(&*pool, id, is_enabled).await
 }
 
 /// Update agent by id.
@@ -169,6 +186,7 @@ pub async fn update_agent(request: UpdateAgent, pool: State<'_, DbPool>) -> Resu
         description: agent.description,
         system_message: agent.system_message,
         ability_ids: request.ability_ids,
+        is_enabled: agent.is_enabled,
         created_at: agent.created_at,
         updated_at: agent.updated_at,
     })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an "Enabled" status for agents, allowing users to enable or disable agents directly.
	- Enhanced task execution with better message handling and status updates, improving user feedback during task operations.

- **Database Updates**
	- Added a new `is_enabled` field to the agents table to support enabling or disabling agents.
	- Updated database queries to handle the new `is_enabled` field for agents.

- **Bug Fixes**
	- Fixed issues related to message handling in task execution, ensuring smoother operation and feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->