### PR TITLE
Change python container image from standard (1.2 GB) to slim (130MB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ it [installed on your system](https://docs.docker.com/get-docker/).
 After installing Docker, run the following commands:
 
 ```shell
-docker pull python:3.12
+docker pull python:slim
 docker container run -it --rm -p 9515:9515 zenika/alpine-chrome:with-chromedriver
 ```
 

--- a/src-tauri/src/docker.rs
+++ b/src-tauri/src/docker.rs
@@ -13,7 +13,7 @@ use tracing::trace;
 
 use crate::types::Result;
 
-const DEFAULT_IMAGE: &str = "python:3.12";
+const DEFAULT_IMAGE: &str = "python:slim";
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {


### PR DESCRIPTION
python image optimisation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Docker image in the installation instructions to `python:slim` for improved efficiency.
- **Refactor**
	- Changed the default Docker image to `python:slim` to optimize performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->